### PR TITLE
Fix code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/public/controllers/users.controller.js
+++ b/public/controllers/users.controller.js
@@ -46,11 +46,15 @@ const putUser = async (req, res) => {
 
     const { nombre, correo, clave, estado } = req.body // Destructuring the request body to get the user's updated name, email, password, and status
 
+    if (typeof nombre !== 'string' || typeof correo !== 'string' || typeof clave !== 'string' || typeof estado !== 'string') {
+        return res.status(400).json({ success: false, message: 'Invalid input data' });
+    }
+
     const salt = bcryptjs.genSaltSync() 
 
     const hashClave = bcryptjs.hashSync(clave, salt) 
 
-    const user = await User.findByIdAndUpdate(id, { nombre, correo, clave: hashClave, estado }) // Updating a User object with the destructured data
+    const user = await User.findByIdAndUpdate(id, { $set: { nombre, correo, clave: hashClave, estado } }) // Updating a User object with the destructured data
 
     res.status(200).json({ 
         success: true,


### PR DESCRIPTION
Fixes [https://github.com/VanegasYW/APIRest-Basic/security/code-scanning/5](https://github.com/VanegasYW/APIRest-Basic/security/code-scanning/5)

To fix the problem, we need to ensure that the user-provided data is properly sanitized before being used in the query object. For MongoDB, we can use the `$set` operator to ensure that the data is interpreted as a literal value. Additionally, we should validate the user input to ensure it meets expected formats and types.

1. Validate the user input to ensure it is of the expected type and format.
2. Use the `$set` operator to safely update the user document.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
