### PR TITLE
Fix code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/public/routes/users.routes.js
+++ b/public/routes/users.routes.js
@@ -14,7 +14,14 @@ const getUsersLimiter = rateLimit({
 
 // Apply rate limiter to getUsers route
 router.get("/", getUsersLimiter, getUsers)
-router.get("/:id",getUserById)
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const getUserByIdLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to getUserById route
+router.get("/:id", getUserByIdLimiter, getUserById)
 router.post("/",  postUser)
 // Configure rate limiter: maximum of 100 requests per 15 minutes
 const putUserLimiter = rateLimit({


### PR DESCRIPTION
Fixes [https://github.com/VanegasYW/APIRest-Basic/security/code-scanning/8](https://github.com/VanegasYW/APIRest-Basic/security/code-scanning/8)

To fix the problem, we need to apply a rate limiter to the `getUserById` route. This can be done by creating a rate limiter instance and applying it to the route in a similar manner to the other routes. We will use the `express-rate-limit` package, which is already imported in the file. The rate limiter will be configured to allow a maximum of 100 requests per 15 minutes from a single IP address.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
